### PR TITLE
Use official app-id in Desktop file

### DIFF
--- a/freetube.spec
+++ b/freetube.spec
@@ -6,9 +6,8 @@
 
 Name: %{_app}
 Version: %{release_tag}
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Open source desktop YouTube player built with privacy in mind.
-Group: System/GUI/Internet
 License: AGPL-3.0-only
 
 URL: https://github.com/%{dev}/%{app}
@@ -39,7 +38,7 @@ Name=FreeTube
 Exec=freetube %U
 Terminal=false
 Type=Application
-Icon=FreeTube
+Icon=io.freetubeapp.FreeTube
 StartupWMClass=FreeTube
 Comment=An open source desktop YouTube player built with privacy in mind.
 MimeType=x-scheme-handler/freetube;


### PR DESCRIPTION
This is the app-id the official [Flatpak](https://flathub.org/en/apps/io.freetubeapp.FreeTube) uses:
```sh
❯ grep Icon /var/lib/flatpak/exports/share/applications/io.freetubeapp.FreeTube.desktop 
Icon=io.freetubeapp.FreeTube
```

The RPM and deb use `freetube` instead (but app-id is case sensitive), however those are autogenerated packages which are notoriously bad about sticking to specs and using the reverse DNS notation just makes sense.

This change makes sure that icon themes can associate their icons with this desktop entry.

I was also thinking about changing the filename to `io.freetubeapp.FreeTube.desktop`, but I left it for now.

---

Additionally:

- remove deprecated and discouraged `Group:` definition

This tag has been deprecated and discouraged for a decade now:

- https://fedoraproject.org/wiki/RPMGroups
- https://pagure.io/packaging-committee/issue/679